### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": "^8.1",
         "composer/installers": "~1.0",
         "imagina/core-module": "v10.x-dev",
-        "paragonie/random_compat":"2.*",
         "laravel/passport": "^11.5",
         "laravel/socialite": "^5.9",
         "fruitcake/php-cors": "^1.2",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: 2.*`, but also `php: ^8.1`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?